### PR TITLE
Add metrics

### DIFF
--- a/src/query/storage/cache/redis_cache.go
+++ b/src/query/storage/cache/redis_cache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/m3db/m3/src/query/generated/proto/prompb"
 	"github.com/m3db/m3/src/query/storage"
 	radix "github.com/mediocregopher/radix/v3"
+	"github.com/uber-go/tally"
 
 	"go.uber.org/zap"
 )
@@ -20,23 +21,74 @@ const (
 	ExpirationTime string = "300"
 	// Blank result used to denote an empty PromResult
 	EmptyResult string = "{}"
+	// Minimum number of connections pools to Redis to keep open
+	MinPools int = 10
+	// Time to wait before creating a new Redis connection pool (in ms)
+	CreateAfterTime time.Duration = 100 * time.Millisecond
 )
 
 type RedisCache struct {
 	client       radix.Client
 	redisAddress string
 	logger       *zap.Logger
+	cacheMetrics CacheMetrics
+}
+
+// Struct for tracking stats for cache
+type CacheMetrics struct {
+	hitCounter        tally.Counter
+	hitSamplesCounter tally.Counter
+	hitBytesCounter   tally.Counter
+
+	missCounter        tally.Counter
+	missSamplesCounter tally.Counter
+	missBytesCounter   tally.Counter
+}
+
+func NewCacheMetrics(scope tally.Scope) CacheMetrics {
+	subScope := scope.SubScope("cache")
+	return CacheMetrics{
+		hitCounter:        subScope.Counter("hit"),
+		hitSamplesCounter: subScope.Counter("hit-samples"),
+		hitBytesCounter:   subScope.Counter("hit-bytes"),
+
+		missCounter:        subScope.Counter("miss"),
+		missSamplesCounter: subScope.Counter("miss-samples"),
+		missBytesCounter:   subScope.Counter("miss-bytes"),
+	}
+}
+
+// Update metrcis for a cache hit
+func (cm CacheMetrics) CacheMetricsHit(result storage.PromResult) {
+	cm.hitCounter.Inc(1)
+	tot_samples := 0
+	for _, ts := range result.PromResult.Timeseries {
+		tot_samples += len(ts.Samples)
+	}
+	cm.hitSamplesCounter.Inc(int64(tot_samples))
+	cm.hitBytesCounter.Inc(int64(result.PromResult.Size()))
+}
+
+// Update metrics for a cache miss
+func (cm CacheMetrics) CacheMetricsMiss(result storage.PromResult) {
+	cm.missCounter.Inc(1)
+	tot_samples := 0
+	for _, ts := range result.PromResult.Timeseries {
+		tot_samples += len(ts.Samples)
+	}
+	cm.missSamplesCounter.Inc(int64(tot_samples))
+	cm.missBytesCounter.Inc(int64(result.PromResult.Size()))
 }
 
 // Create new RedisCache
 // If redisAddress is "" or a connection can't be made, returns nil
-func NewRedisCache(redisAddress string, logger *zap.Logger) *RedisCache {
+func NewRedisCache(redisAddress string, logger *zap.Logger, scope tally.Scope) *RedisCache {
 	logger.Info("New Cache", zap.String("address", redisAddress))
 	if redisAddress == "" {
 		logger.Info("Not using cache since address is empty")
 		return nil
 	}
-	pool, err := radix.NewPool("tcp", redisAddress, 10, radix.PoolOnEmptyCreateAfter(time.Millisecond*100))
+	pool, err := radix.NewPool("tcp", redisAddress, MinPools, radix.PoolOnEmptyCreateAfter(CreateAfterTime))
 	if err != nil {
 		logger.Error("Failed to connect to Redis", zap.String("address", redisAddress))
 		return nil
@@ -46,6 +98,7 @@ func NewRedisCache(redisAddress string, logger *zap.Logger) *RedisCache {
 		client:       pool,
 		redisAddress: redisAddress,
 		logger:       logger,
+		cacheMetrics: NewCacheMetrics(scope),
 	}
 }
 
@@ -207,8 +260,10 @@ func WindowGetOrFetch(
 		}
 
 		cache.logger.Info("cache miss", zap.String("key", keyEncode(align_q)), zap.Int("size", len(promRes.PromResult.Timeseries)))
+		cache.cacheMetrics.CacheMetricsMiss(promRes)
 		return promRes, err
 	}
 	cache.logger.Info("cache hit", zap.String("key", keyEncode(align_q)))
+	cache.cacheMetrics.CacheMetricsHit(*res[0])
 	return *res[0], nil
 }

--- a/src/query/storage/cache/redis_cache_test.go
+++ b/src/query/storage/cache/redis_cache_test.go
@@ -1,4 +1,4 @@
-// Basic unit tests for Redis cache (not comprehensive, just a quick sanity check)
+// Simple unit tests for Redis cache
 // This test suite requires setting up a Redis instance at
 // 127.0.0.1:6379 (localhost)
 
@@ -15,6 +15,7 @@ import (
 	"github.com/m3db/m3/src/query/storage"
 	radix "github.com/mediocregopher/radix/v3"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -23,7 +24,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	cache = *NewRedisCache("127.0.0.1:6379", zap.NewExample())
+	cache = *NewRedisCache("127.0.0.1:6379", zap.NewExample(), tally.NewTestScope("", make(map[string]string, 0)))
 	var response string
 	cache.client.Do(radix.Cmd(&response, "FLUSHALL"))
 	m.Run()

--- a/src/query/storage/prometheus/prometheus_storage.go
+++ b/src/query/storage/prometheus/prometheus_storage.go
@@ -87,7 +87,7 @@ func NewPrometheusQueryable(opts PrometheusOptions) promstorage.Queryable {
 		storage: opts.Storage,
 		scope:   scope,
 		logger:  opts.InstrumentOptions.Logger(),
-		cache:   cache.NewRedisCache(opts.RedisCacheAddress, opts.InstrumentOptions.Logger()),
+		cache:   cache.NewRedisCache(opts.RedisCacheAddress, opts.InstrumentOptions.Logger(), scope),
 	}
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
PR stacked on [initial PR](https://github.com/databricks/m3/pull/4)
Implementing metric recording for cache

<!--
   See http://go/pr-description for tips on what to write here
   New to Databricks? See http://go/pr-process

   [NEW] Please review if shiproom approval is required.
   See the Shiproom section below for details.
-->

## How is this tested?
Deployed to `dev-aws-us-west-1`. Monitored performance metrics on [dashboard](https://grafana.cloud.databricks.com/d/jfb0fkenz/m3coordinator-cache-monitoring?orgId=1&from=now-1h&to=now). Observed caching rate similar to local hackathon cache rate

<!--
  - Added unit or integration tests? Please mention them here.
  - Performed manual testing? Please describe your testing procedure.
  - Was testing unnecessary or not possible? Please explain why.
-->

## How is this feature monitored?
<!--
  - Did you add usage logs or metrics? Please mention them here.
  - Create dashboards or monitoring notebooks? Please link them here.
  - See http://go/obs/user for docs on our observability tools.
-->

#### Code Review
For information about the code review process, e.g. how to find a reviewer or how to ping non-responsive reviewers, check the contents of [go/code-review](http://go/code-review) Confluence page.

#### Approvals
Other than the mandatory approvers enforced by the OWNER file framework (http://go/owners), this PR
requires at least one approval from another engineer.

#### [NEW] Shiproom

**Platform & Compute Fabric**:
Changes should be tracked by an approved "material change." Multiple PRs may be tracked by a single material change.

- [ ] Change modifies code owned or released by a Platform or Compute Fabric team
  - [ ] A "material change" covering this PR exists in http://go/engshiproom: `<CHANGE_ID>`

See http://go/platshiproomwiki for instructions and use http://go/lightcm-template to evaluate risk. Ask questions in #platform-shiproom.

**Runtime changes**:
- [ ] Change targets a runtime maintenance release (i.e., targets a maintenance `dbr-branch-x.x` branch or has a maintenance `dbr-branch-x.x` label)
  - [ ] Change is **NOT** a “material change”
  - [ ] Change **IS** a “material change” of low / medium risk
  - [ ] Change **IS** a “material change” of high risk needing Shiproom review

Please refer Runtime Shiproom Wiki: http://go/runtimeshiproomwiki

#### Security implications
_This section is intended for the reviewers of this PR_
Please, make sure you consider the content of "What are the responsibilities of code reviewers?" section of [go/pr-security-review](http://go/pr-security-review)
